### PR TITLE
Check if nodes actually exist in EC2 and include status in output

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -20,12 +20,19 @@ Available options are:
 * -H, --hours HOURS
 * -m, --minutes MINUTES
 * -r, --reverse
+* -e, --use-ec2
 
 These options can be used together so:
 
     knife stalenodes -H 4 -m 30 -r
 
 Will show all the nodes that have checked in within the last 4.5 hours
+
+Add the following to your knife.rb to permanently enable --use-ec2:
+
+    knife[:stalenodes] = {
+      :use_ec2 => true
+    }
 
 = WARNING:
 

--- a/lib/chef/knife/stalenodes.rb
+++ b/lib/chef/knife/stalenodes.rb
@@ -63,6 +63,16 @@ module KnifeStalenodes
         :description  => "Max number of hosts to search",
         :default      => 2500
 
+    option :use_ec2,
+        :short        => "-e",
+        :long         => "--use-ec2",
+        :description  => "Indicate whether or not stale nodes are present in ec2",
+        :default      => false,
+        :proc => Proc.new { |key|
+          Chef::Config[:knife][:stalenodes] ||= {}
+          Chef::Config[:knife][:stalenodes][:use_ec2] = key
+        }
+
 
     def calculate_time
       seconds = config[:days].to_i * 86400 + config[:hours].to_i * 3600 + config[:minutes].to_i * 60
@@ -115,7 +125,8 @@ module KnifeStalenodes
     end
 
     def use_ec2?
-      if Chef::Config[:knife][:aws_access_key_id]
+      if Chef::Config[:knife][:stalenodes] &&
+        Chef::Config[:knife][:stalenodes][:use_ec2]
         return true
       else
         return false


### PR DESCRIPTION
Only runs if aws_access_key_id knife option is detected so as not to create a dependency on EC2.

(PS. My editor also removed a bunch of trailing spaces ;-))
